### PR TITLE
[FEAT] refactoring recipe

### DIFF
--- a/src/main/kotlin/com/mukjipsa/domain/Recipe.kt
+++ b/src/main/kotlin/com/mukjipsa/domain/Recipe.kt
@@ -33,6 +33,9 @@ class Recipe(
         var updatedAt: LocalDateTime? = LocalDateTime.now(),
 
         @OneToMany
-        @JoinColumn(name = "id")
-        val ingredients: MutableList<Ingredient> = mutableListOf()
+        @JoinTable(name = "recipe_ingredient", //조인테이블명
+                joinColumns = [JoinColumn(name = "recipe_id")],  //외래키
+                inverseJoinColumns = [JoinColumn(name = "ingredient_id")]//반대 엔티티의 외래키
+        )
+        val ingredients: List<Ingredient> = listOf()
 )

--- a/src/main/kotlin/com/mukjipsa/domain/User.kt
+++ b/src/main/kotlin/com/mukjipsa/domain/User.kt
@@ -31,6 +31,9 @@ class User(
         var updatedAt: LocalDateTime = LocalDateTime.now(),
 
         @OneToMany
-        @JoinColumn(name = "id")
+        @JoinTable(name = "user_ingredient", //조인테이블명
+                joinColumns = [JoinColumn(name = "user_id")],  //외래키
+                inverseJoinColumns = [JoinColumn(name="ingredient_id")] //반대 엔티티의 외래키
+        )
         val ingredient: MutableList<Ingredient> = mutableListOf()
 )

--- a/src/main/kotlin/com/mukjipsa/facade/RecipeFacade.kt
+++ b/src/main/kotlin/com/mukjipsa/facade/RecipeFacade.kt
@@ -9,9 +9,6 @@ import org.springframework.stereotype.Service
 @Service
 class RecipeFacade(
         private val recipeService: RecipeService,
-        private val userIngredientService: UserIngredientService,
-        private val recipeIngredientService: RecipeIngredientService,
-        private val ingredientService: IngredientService,
         private val userService: UserService,
 ) {
     // 레시피 전체 조회
@@ -19,10 +16,6 @@ class RecipeFacade(
         val recipeList = recipeService.getAllRecipe()
         val recipeListDto = mutableListOf<RecipeSimpleDto>()
         recipeList.map {
-            val ingredientIds = recipeIngredientService.getIngredientByRecipeId(it.id).map {
-                it.ingredientId
-            }
-            val ingredientList = ingredientService.getIngredientByIdIn(ingredientIds)
             val recipeSimpleDto: RecipeSimpleDto = RecipeSimpleDto(
                     id = it.id,
                     content = it.content,
@@ -31,7 +24,7 @@ class RecipeFacade(
                     title = it.title,
                     createdAt = it.createdAt,
                     updatedAt = it.updatedAt,
-                    ingredients = ingredientList.map {
+                    ingredients = it.ingredients.map {
                         IngredientSimpleDto(
                                 categoryType = it.category.name,
                                 id = it.id,
@@ -58,13 +51,6 @@ class RecipeFacade(
             it.id
         }
 
-        //recipe Id를 가진 ingredient 불러오기
-        val ingredientIds = recipeIngredientService.getIngredientByRecipeId(recipeId).map {
-            it.ingredientId
-        }
-
-        val ingredientList = ingredientService.getIngredientByIdIn(ingredientIds)
-
         val recipe = recipeService.getRecipe(recipeId).get()
 
         val recipeDto: RecipeDto = RecipeDto(
@@ -75,7 +61,7 @@ class RecipeFacade(
                 title = recipe.title,
                 createdAt = recipe.createdAt,
                 updatedAt = recipe.updatedAt,
-                ingredients = ingredientList.map {
+                ingredients = recipe.ingredients.map {
                     IngredientDto(
                             categoryType = it.category.name,
                             id = it.id,
@@ -110,9 +96,7 @@ class RecipeFacade(
             var flag = false;
 
             // 해당 레시피의 모든 ingredient Id
-            val ingredientIds = recipeIngredientService.getIngredientByRecipeId(it.id).map {
-                it.ingredientId
-            }
+            val ingredientIds = it.ingredients.map { it.id }
 
             ingredientIds.map {
                 if (!haveIngredientId.contains(it)) { // 재료 중 하나라도 없다면
@@ -120,9 +104,6 @@ class RecipeFacade(
                 }
             }
             if (!flag) {
-                // 해당 레시피의 모든 재료
-                val ingredientList = ingredientService.getIngredientByIdIn(ingredientIds)
-
                 val recipeDto: RecipeDto = RecipeDto(
                         id = it.id,
                         content = it.content,
@@ -131,7 +112,7 @@ class RecipeFacade(
                         title = it.title,
                         createdAt = it.createdAt,
                         updatedAt = it.updatedAt,
-                        ingredients = ingredientList.map {
+                        ingredients = it.ingredients.map {
                             IngredientDto(
                                     categoryType = it.category.name,
                                     id = it.id,
@@ -153,6 +134,4 @@ class RecipeFacade(
         )
 
     }
-
-
 }


### PR DESCRIPTION
- 현재 recipe의 재료를 가져오는 로직이 쿼리를 너무 많이 발생시키고 있습니다.
- 기존 -> recipeId로 recipeIngredient 조회 recipeingredient의 ingredientId로 ingredient 조회
- 기존의 단점 -> recipe갯수 * 3 개의 쿼리 발생.
- 해결방안 현재 entity에 매핑관계가 생성되어 있으므로 recipe 엔티티가 들고 있는 ingredients 사용.

